### PR TITLE
Allow uuid to be specified.

### DIFF
--- a/ce_deploy.module
+++ b/ce_deploy.module
@@ -88,6 +88,10 @@ function ce_deploy_create_taxonomy($filename) {
               if (isset($taxonomy_file['langcode'])) {
                 $term_values['langcode'] = $taxonomy_file['langcode'];
               }
+              
+              if (isset($taxonomy_file['uuid'])) {
+                $vocabulary_values['uuid'] = $taxonomy_file['uuid'];
+              }
 
               // Add description if exists.
               if (isset($term['description'])) {


### PR DESCRIPTION
**Problem**
Current deployment scripts perform db updates and then, config-import. For vocabularies created locally, that means the config-exported will have some given UUID, but the Vocabulary created in a remote environment via ce_deploy a different one. 

The result is that the follow-up config-import done by the deployment will crash, as it'll attempt to create the same vocabulary that already exists.

**Proposed Solution**

Specifying the 'uuid' in our .yml files prevents this.