### PR TITLE
Basic block deployment functionality.

### DIFF
--- a/ce_deploy.module
+++ b/ce_deploy.module
@@ -66,7 +66,7 @@ function ce_deploy_create_taxonomy($filename) {
           if (isset($taxonomy_file['langcode'])) {
             $vocabulary_values['langcode'] = $taxonomy_file['langcode'];
           }
-          
+
           if (isset($taxonomy_file['uuid'])) {
             $vocabulary_values['uuid'] = $taxonomy_file['uuid'];
           }
@@ -106,4 +106,46 @@ function ce_deploy_create_taxonomy($filename) {
       }
     }
   }
+}
+
+/**
+ * Creates block contents from .yml files.
+ *
+ * @param string $filename
+ *  The name of the .yml file to get data from (under root://data/block/).
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function ce_deploy_create_block($filename) {
+	$file_path = DRUPAL_ROOT . "/../data/block/" . $filename . ".yml";
+
+	if (file_exists($file_path)) {
+		// Read YAML file to get attributes.
+		$block_file = Yaml::decode(file_get_contents($file_path));
+		if ($block_file) {
+			foreach ($block_file['blocks'] as $block_entry) {
+				$uuid = $block_entry['uuid'];
+
+				$block = \Drupal::service('entity.repository')
+												->loadEntityByUuid('block_content', $uuid);
+
+				// Existing blocks are not imported again.
+				if ($block) {
+					continue;
+				}
+
+				$values = [
+					'type' => $block_file['bundle'],
+					'info' => $block_entry['title'],
+					'uuid' => $block_entry['uuid'],
+					'status' => 1,
+				];
+
+				$block = \Drupal\block_content\Entity\BlockContent::create($values);
+				$block->body->value = $block_entry['value'];
+				$block->body->format = $block_entry['format'];
+				$block->save();
+			}
+		}
+	}
 }

--- a/examples/data/block/block.basic.yml
+++ b/examples/data/block/block.basic.yml
@@ -1,0 +1,13 @@
+bundle: basic
+blocks:
+  - title: State of Treaty and Ratification
+    uuid: 5d80f851-794d-45a1-a3da-25139f3249c2
+    format: full_html
+    value: >
+      To commemorate the 20th anniversary of the opening for signature of
+      the Comprehensive Nuclear-Test-Ban Treaty (CTBT) a number of high-level
+      events are being organized throughout 2016. This publication was launched
+      to coincide with the Ministerial Meeting in June 2016. It relates the
+      genesis of the Treaty since the creation of the Conference on Disarmament
+      of 1979, as well as the challenges and achievements toward the entry
+      into force that have taken place over the last twenty years.


### PR DESCRIPTION
Basic block deployment via .yml files.

Still not sure we wouldn't be better off by standardising on a way of setting up default contents (e.g: migrate default content), but in lack of that, this will do for those *content blocks* that might need referencing from a panels page hence need the UUID for config export, etc.
