### PR TITLE
BabyPL: field_children and property twig helpers.

### DIFF
--- a/ce_deploy.services.yml
+++ b/ce_deploy.services.yml
@@ -1,0 +1,5 @@
+services:
+  ctbto_core.twig.template_field_utils:
+    class: Drupal\ce_deploy\Template\FieldUtilsExtension
+    tags:
+      - { name: twig.extension }

--- a/src/Template/FieldUtilsExtension.php
+++ b/src/Template/FieldUtilsExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\ce_deploy\Template;
+
+use Drupal\Core\Render\Element;
+
+/**
+ * Class FieldUtilsExtension
+ */
+class FieldUtilsExtension extends \Twig_Extension {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFunctions() {
+    return [
+      new \Twig_SimpleFunction('field_children', [$this, 'getFieldChildren']),
+      new \Twig_SimpleFunction('property', [$this, 'getProperty']),
+    ];
+  }
+
+  /**
+   * This serves to get the actual children of a given field (Render array).
+   * Useful as well to get an empty array for an empty field.
+   *
+   * @return array
+   */
+  public function getFieldChildren($fieldArray) {
+    $childrenKeys = Element::children($fieldArray);
+    $result = array_intersect_key($fieldArray, $childrenKeys);
+    return $result;
+  }
+
+  /**
+   * @param $renderArray
+   * @param $propertyName
+   */
+  public function getProperty($renderArray, $propertyName) {
+    return $renderArray[$propertyName] ?? null;
+  }
+
+}


### PR DESCRIPTION
This should live in a ce_core module, since themes can't declare services, but I can't create repos, so better here than nowhere, for now!

Just 2 helpers to help keep templates clean. One of them is to extract specific properties of render arrays (e.g: *#links* if dealing with a breadcrumb), so that they can be assigned easily to a variable, and delegate the rendering to the Patternlab template.

The other, **field_children** comes handy to get just the actual child items of a given render array (avoiding properties). 